### PR TITLE
move logic for add/remove table columns

### DIFF
--- a/upload/admin/controller/extension/shipping/collivery.php
+++ b/upload/admin/controller/extension/shipping/collivery.php
@@ -1,17 +1,64 @@
 <?php
 
-class ControllerExtensionShippingCollivery extends Controller {
+class ModelExtensionShippingCollivery extends Model {
 
-    public function index() {
+    private $columns = array(
+        'order' => array(
+            'collivery_from_address_id',
+            'collivery_from_contact_id',
+            'collivery_to_address_id',
+            'collivery_to_contact_id',
+            'collivery_town',
+            'collivery_suburb',
+            'collivery_location_type',
+            'collivery_price_data',
+            'collivery_service_type_id',
+            'waybill_id'
+        ),
+        'address' => array(
+            'collivery_town',
+            'collivery_suburb',
+            'collivery_location_type',
+        )
+    );
+
+    public function addColumns() {
+        foreach ($this->columns as $table => $columns) {
+            foreach ($columns as $column) {
+                if ($this->rowQuery($table, $column)) {
+                    continue;
+                }
+                $this->addColumn($table, $column);
+            }
+        }
 
     }
 
-    public function install() {
-
+    public function dropColumns() {
+        foreach ($this->columns as $table => $columns) {
+            foreach ($columns as $column) {
+                if ($this->rowQuery($table, $column)) {
+                    $this->dropColumn($table, $column);
+                }
+            }
+        }
     }
 
-    public function uninstall() {
-
+    private function addColumn($table, $column)
+    {
+        $this->db->query("ALTER TABLE `".DB_PREFIX."{$table}` ADD `{$column}` VARCHAR(255) NULL DEFAULT NULL;");
     }
+
+    private function dropColumn($table, $column)
+    {
+        $this->db->query("ALTER TABLE `".DB_PREFIX."{$table}` DROP COLUMN `{$column}`;");
+    }
+
+    private function rowQuery($table, $column)
+    {
+        $o= $this->db->query("SELECT * FROM `INFORMATION_SCHEMA`.`COLUMNS` WHERE `TABLE_NAME` = '".DB_PREFIX."{$table}' AND `TABLE_SCHEMA` = '".DB_DATABASE."' AND `COLUMN_NAME` = '{$column}';");
+        return $o->num_rows > 0;
+    }
+
 
 }

--- a/upload/catalog/model/extension/shipping/collivery.php
+++ b/upload/catalog/model/extension/shipping/collivery.php
@@ -1,1 +1,19 @@
 <?php
+
+class ControllerExtensionShippingCollivery extends Controller {
+
+    public function index() {
+
+    }
+
+    public function install() {
+        $this->load->model('extension/shipping/collivery');
+        $this->model_extension_shipping_collivery->addColumns();
+    }
+
+    public function uninstall() {
+        $this->load->model('extension/shipping/collivery');
+        $this->model_extension_shipping_collivery->dropColumns();
+    }
+
+}


### PR DESCRIPTION
move logic for add/remove table columns from XML to model when a plugin is being installed or install
this is to clean up the code

table` order`

- collivery_from_address_id
- collivery_from_contact_id
- collivery_to_address_id
- collivery_to_contact_id
- collivery_town
- collivery_suburb
- collivery_location_type
- collivery_price_data
- collivery_service_type_id
- waybill_id

table` address`

- collivery_town
- collivery_suburb
- collivery_location_type